### PR TITLE
update to make SimpleAccountFactory deployable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ artifacts
 .DS_Store
 /contracts/dist/
 /contracts/types/
+.env

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,12 +5,9 @@ import 'hardhat-deploy'
 import '@nomiclabs/hardhat-etherscan'
 
 import 'solidity-coverage'
+require('dotenv').config()
 
-import * as fs from 'fs'
-
-const mnemonicFileName = process.env.MNEMONIC_FILE ?? `${process.env.HOME}/.secret/testnet-mnemonic.txt`
-let mnemonic = 'test '.repeat(11) + 'junk'
-if (fs.existsSync(mnemonicFileName)) { mnemonic = fs.readFileSync(mnemonicFileName, 'ascii') }
+const mnemonic = process.env.MNEMONIC as string
 
 function getNetwork1 (url: string): { url: string, accounts: { mnemonic: string } } {
   return {
@@ -20,7 +17,7 @@ function getNetwork1 (url: string): { url: string, accounts: { mnemonic: string 
 }
 
 function getNetwork (name: string): { url: string, accounts: { mnemonic: string } } {
-  return getNetwork1(`https://${name}.infura.io/v3/${process.env.INFURA_ID}`)
+  return getNetwork1(`https://${name}.g.alchemy.com/v2/${process.env.ALCHEMY_KEY}`)
   // return getNetwork1(`wss://${name}.infura.io/ws/v3/${process.env.INFURA_ID}`)
 }
 
@@ -52,7 +49,7 @@ const config: HardhatUserConfig = {
     dev: { url: 'http://localhost:8545' },
     // github action starts localgeth service, for gas calculations
     localgeth: { url: 'http://localgeth:8545' },
-    goerli: getNetwork('goerli'),
+    goerli: getNetwork('eth-goerli'),
     sepolia: getNetwork('sepolia'),
     proxy: getNetwork1('http://localhost:8545')
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@thehubbleproject/bls": "^0.5.1",
     "@typechain/hardhat": "^2.3.0",
     "@types/mocha": "^9.0.0",
+    "dotenv": "^16.0.3",
     "ethereumjs-util": "^7.1.0",
     "ethereumjs-wallet": "^1.0.1",
     "hardhat-deploy": "^0.11.23",

--- a/scripts/sample-script.js
+++ b/scripts/sample-script.js
@@ -14,8 +14,8 @@ async function main () {
   // await hre.run('compile');
 
   // We get the contract to deploy
-  const Singleton = await hre.ethers.getContractFactory('Singleton')
-  const singleton = await Singleton.deploy()
+  const Singleton = await hre.ethers.getContractFactory('SimpleAccountFactory')
+  const singleton = await Singleton.deploy('0x0576a174D229E3cFA37253523E645A78A0C91B57')
 
   await singleton.deployed()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,6 +3481,11 @@ dom-walk@^0.1.0:
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 dotignore@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dotignore/-/dotignore-0.1.2.tgz#f942f2200d28c3a76fbdd6f0ee9f3257c8a2e905"


### PR DESCRIPTION
To deploy SimpleAccountFactory, you have to command the following.
```
$ npx hardhat run --network goerli scripts/sample-script.js
```